### PR TITLE
Optimize redraws to reduce flickering

### DIFF
--- a/lua/comfy-line-numbers/init.lua
+++ b/lua/comfy-line-numbers/init.lua
@@ -130,12 +130,10 @@ function update_status_column()
     if should_hide_numbers(filetype, buftype) then
       vim.api.nvim_win_call(win, function()
         vim.opt.statuscolumn = ''
-        vim.cmd('mod') -- force redraw
       end)
     else
       vim.api.nvim_win_call(win, function()
         vim.opt.statuscolumn = '%=%s%=%{v:lua.get_label(v:lnum, v:relnum)} '
-        vim.cmd('mod') -- force redraw
       end)
     end
   end

--- a/lua/comfy-line-numbers/init.lua
+++ b/lua/comfy-line-numbers/init.lua
@@ -121,21 +121,28 @@ _G.get_label = function(absnum, relnum)
   end
 end
 
+local last_statuscolumn = nil
+
 function update_status_column()
   for _, win in ipairs(vim.api.nvim_list_wins()) do
     local buf = vim.api.nvim_win_get_buf(win)
     local buftype = vim.bo[buf].buftype
     local filetype = vim.bo[buf].filetype
 
-    if should_hide_numbers(filetype, buftype) then
-      vim.api.nvim_win_call(win, function()
-        vim.opt.statuscolumn = ''
-      end)
-    else
-      vim.api.nvim_win_call(win, function()
-        vim.opt.statuscolumn = '%=%s%=%{v:lua.get_label(v:lnum, v:relnum)} '
-      end)
-    end
+		local new_statuscolumn
+		if should_hide_numbers(filetype, buftype) then
+			new_statuscolumn = ''
+		else 
+			new_statuscolumn = '%=%s%=%{v:lua.get_label(v:lnum, v:relnum)} '
+		end
+
+		-- Only update if status column is different
+		if new_statuscolumn ~= last_statuscolumn then
+			vim.api.nvim_win_call(win, function()
+				vim.opt.statuscolumn = new_statuscolumn
+			end)
+			last_statuscolumn = new_statuscolumn
+		end
   end
 end
 


### PR DESCRIPTION
The constant redraws cause a lot of flickering on screen happening especially when using cmp plugins.

Set the line numbers to update only if necessary