### PR TITLE
Add checks for empty labels in keymap settings

### DIFF
--- a/lua/comfy-line-numbers/init.lua
+++ b/lua/comfy-line-numbers/init.lua
@@ -159,8 +159,10 @@ function M.enable_line_numbers()
   end
 
   for index, label in ipairs(M.config.labels) do
-    vim.keymap.set({ 'n', 'v', 'o' }, label .. M.config.up_key, index .. 'k', { noremap = true })
-    vim.keymap.set({ 'n', 'v', 'o' }, label .. M.config.down_key, index .. 'j', { noremap = true })
+    if label ~= "" then
+      vim.keymap.set({ 'n', 'v', 'o' }, label .. M.config.up_key, index .. 'k', { noremap = true })
+      vim.keymap.set({ 'n', 'v', 'o' }, label .. M.config.down_key, index .. 'j', { noremap = true })
+    end
   end
 
   enabled = true
@@ -173,8 +175,10 @@ function M.disable_line_numbers()
   end
 
   for index, label in ipairs(M.config.labels) do
-    vim.keymap.del({ 'n', 'v', 'o' }, label .. M.config.up_key)
-    vim.keymap.del({ 'n', 'v', 'o' }, label .. M.config.down_key)
+    if label ~= "" then
+      vim.keymap.del({ 'n', 'v', 'o' }, label .. M.config.up_key)
+      vim.keymap.del({ 'n', 'v', 'o' }, label .. M.config.down_key)
+    end
   end
 
 


### PR DESCRIPTION
Without this check, the plugin could remap j/k to something like 78k/78j if empty label are provided for the given index.

This allows the very cursed config:
```
labels = {
      '', '1', '', '2', '', '3', '', '4', '', '5', '', '11', '', '12', '', '13', '', '14', '', '15', '', '21', '', '22', '', '23', '', '24', '', '25', '', '31', '', '32', '', '33', '', '34', '', '35', '', '41', '', '42', '', '43', '', '44', '', '45', '', '51', '', '52', '', '53', '', '54', '', '55', '', '111', '', '112', '', '113', '', '114', '', '115', '', '121', '', '122', '', '123', '', '124', '', '125'
    }
```
which is easier on my eyes. Having to call an extra j/k after the numbered jump isn't a big deal for me.

And for what used to be a 3 digits jump (eg`111j`), now to go to the same line I need to use `25jj`, which is the same amount of keys to press while being easier to read the statuscolumn. However it breaks the operator, like (`c11j`)!