### PR TITLE
Add auto-generation of labels based on base and max_digits

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,44 @@ return {
 
 ## Customization
 
+### Simple Configuration (Recommended)
+
+The plugin automatically generates labels based on `base` and `max_digits`:
+
+```lua
+require('comfy-line-numbers').setup({
+  base = 5,         -- Use digits 1-5 (default). Can be 3-9.
+  max_digits = 10,  -- Generate up to 10-digit combinations (default)
+  up_key = 'k',
+  down_key = 'j',
+
+  -- Line numbers will be completely hidden for the following file/buffer types
+  hidden_file_types = { 'undotree' },
+  hidden_buffer_types = { 'terminal', 'nofile' }
+})
+```
+
+**Defaults:** `base = 5`, `max_digits = 10` → **12,207,030 combinations** (you'll never run out!)
+
+### Base and Max Digits Options
+
+**Base** determines which digits are used:
+- `base = 3`: Uses digits {1, 2, 3}
+- `base = 4`: Uses digits {1, 2, 3, 4}
+- `base = 5`: Uses digits {1, 2, 3, 4, 5} (default)
+- ... up to `base = 9`
+
+**Max Digits** determines the longest label:
+- `max_digits = 3`: Labels up to 3 digits (e.g., 555)
+- `max_digits = 5`: Labels up to 5 digits (e.g., 55555)
+- `max_digits = 10`: Labels up to 10 digits (default)
+
+**Minimum requirement:** Your configuration must yield at least 100 combinations. The plugin will error if this isn't met.
+
+### Advanced: Manual Labels
+
+For complete control, specify labels manually (this overrides `base` and `max_digits`):
+
 ```lua
 require('comfy-line-numbers').setup({
   labels = {

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ require('comfy-line-numbers').setup({
 - `max_digits = 4`: Labels up to 4 digits (e.g., 5555)
 - `max_digits = 5`: Labels up to 5 digits (e.g., 55555) (default)
 
+**Note:** Values higher than `max_digits = 5` will generate many more combinations and may cause slower startup times. The plugin will display a warning if you configure `max_digits > 5`.
+
 **Minimum requirement:** The choice of `base` and `max_digits` must meet the 100 combination minimum. The plugin will validate this requirement and display a helpful error message if not met.
 
 ### Advanced: Manual Labels

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ require('comfy-line-numbers').setup({
 - `max_digits = 5`: Labels up to 5 digits (e.g., 55555)
 - `max_digits = 10`: Labels up to 10 digits (default)
 
-**Minimum requirement:** Your configuration must yield at least 100 combinations. The plugin will error if this isn't met.
+**Minimum requirement:** Both configuration methods (auto-generated via `base`/`max_digits` or manual via `labels`) must provide at least 100 combinations. The plugin will validate this requirement and display a helpful error message if not met.
 
 ### Advanced: Manual Labels
 
-For complete control, specify labels manually (this overrides `base` and `max_digits`):
+For complete control, specify labels manually (this overrides `base` and `max_digits`). Note that manual labels must also meet the minimum 100 combinations requirement:
 
 ```lua
 require('comfy-line-numbers').setup({

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ require('comfy-line-numbers').setup({
 - `max_digits = 5`: Labels up to 5 digits (e.g., 55555)
 - `max_digits = 10`: Labels up to 10 digits (default)
 
-**Minimum requirement:** Both configuration methods (auto-generated via `base`/`max_digits` or manual via `labels`) must provide at least 100 combinations. The plugin will validate this requirement and display a helpful error message if not met.
+**Minimum requirement:** The choice of `base` and `max_digits` must meet the 100 combination minimum. The plugin will validate this requirement and display a helpful error message if not met.
 
 ### Advanced: Manual Labels
 
-For complete control, specify labels manually (this overrides `base` and `max_digits`). Note that manual labels must also meet the minimum 100 combinations requirement:
+For complete control, specify labels manually (this overrides `base` and `max_digits`). Note that manual labels must also meet the minimum 100 combination requirement:
 
 ```lua
 require('comfy-line-numbers').setup({

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ The plugin automatically generates labels based on `base` and `max_digits`:
 
 ```lua
 require('comfy-line-numbers').setup({
-  base = 5,         -- Use digits 1-5 (default). Can be 3-9.
-  max_digits = 10,  -- Generate up to 10-digit combinations (default)
+  base = 5,        -- Use digits 1-5 (default). Can be 3-9.
+  max_digits = 5,  -- Generate up to 5-digit combinations (default)
   up_key = 'k',
   down_key = 'j',
 
@@ -78,7 +78,7 @@ require('comfy-line-numbers').setup({
 })
 ```
 
-**Defaults:** `base = 5`, `max_digits = 10` → **12,207,030 combinations** (you'll never run out!)
+**Defaults:** `base = 5`, `max_digits = 5` → **3,905 combinations** (plenty for most files!)
 
 ### Base and Max Digits Options
 
@@ -90,8 +90,8 @@ require('comfy-line-numbers').setup({
 
 **Max Digits** determines the longest label:
 - `max_digits = 3`: Labels up to 3 digits (e.g., 555)
-- `max_digits = 5`: Labels up to 5 digits (e.g., 55555)
-- `max_digits = 10`: Labels up to 10 digits (default)
+- `max_digits = 4`: Labels up to 4 digits (e.g., 5555)
+- `max_digits = 5`: Labels up to 5 digits (e.g., 55555) (default)
 
 **Minimum requirement:** The choice of `base` and `max_digits` must meet the 100 combination minimum. The plugin will validate this requirement and display a helpful error message if not met.
 

--- a/lua/comfy-line-numbers/init.lua
+++ b/lua/comfy-line-numbers/init.lua
@@ -5,6 +5,9 @@
 
 local enabled = false
 
+-- Minimum number of label combinations required
+local MIN_COMBINATIONS = 100
+
 -- Calculate total number of combinations for given base and max_digits
 -- Formula: base^1 + base^2 + ... + base^max_digits = (base^(max_digits+1) - base) / (base - 1)
 local function calculate_combinations(base, max_digits)
@@ -24,11 +27,11 @@ local function generate_labels(base, max_digits)
   end
 
   local total_combinations = calculate_combinations(base, max_digits)
-  if total_combinations < 100 then
+  if total_combinations < MIN_COMBINATIONS then
     error(string.format(
-      "Configuration yields only %d combinations (minimum 100 required). " ..
+      "Configuration yields only %d combinations (minimum %d required). " ..
       "Please increase base (currently %d) or max_digits (currently %d) or both.",
-      total_combinations, base, max_digits
+      total_combinations, MIN_COMBINATIONS, base, max_digits
     ))
   end
 
@@ -254,12 +257,12 @@ function M.setup(config)
 
     config.labels = generate_labels(base, max_digits)
   else
-    -- If labels IS provided, validate it has at least 100 combinations
-    if #config.labels < 100 then
+    -- If labels IS provided, validate it has at least MIN_COMBINATIONS
+    if #config.labels < MIN_COMBINATIONS then
       error(string.format(
-        "Manual labels configuration has only %d combinations (minimum 100 required). " ..
-        "Please provide at least 100 labels.",
-        #config.labels
+        "Manual labels configuration has only %d combinations (minimum %d required). " ..
+        "Please provide at least %d labels.",
+        #config.labels, MIN_COMBINATIONS, MIN_COMBINATIONS
       ))
     end
   end

--- a/lua/comfy-line-numbers/init.lua
+++ b/lua/comfy-line-numbers/init.lua
@@ -253,8 +253,16 @@ function M.setup(config)
     end
 
     config.labels = generate_labels(base, max_digits)
+  else
+    -- If labels IS provided, validate it has at least 100 combinations
+    if #config.labels < 100 then
+      error(string.format(
+        "Manual labels configuration has only %d combinations (minimum 100 required). " ..
+        "Please provide at least 100 labels.",
+        #config.labels
+      ))
+    end
   end
-  -- If labels IS provided, use it directly (ignore base and max_digits)
 
   M.config = vim.tbl_deep_extend("force", M.config, config)
 

--- a/lua/comfy-line-numbers/init.lua
+++ b/lua/comfy-line-numbers/init.lua
@@ -283,6 +283,18 @@ function M.setup(config)
       error("base must be between 3 and 9")
     end
 
+    -- Warn if max_digits is high, as this can impact startup time
+    if max_digits > 5 then
+      vim.notify(
+        string.format(
+          "comfy-line-numbers: max_digits=%d will generate %d combinations, which may cause slower startup times. Consider using max_digits=5 or less.",
+          max_digits,
+          calculate_combinations(base, max_digits)
+        ),
+        vim.log.levels.WARN
+      )
+    end
+
     config.labels = generate_labels(base, max_digits)
     config.base = base  -- Store base for width calculation
   else


### PR DESCRIPTION
## Summary
This PR simplifies the plugin configuration by adding auto-generation of label combinations. Users can now simply specify a `base` (3-9) and optionally `max_digits` instead of manually listing all label combinations using `labels`.

**Key changes:**
- Added `base` config option (default: 5) - determines which digits to use (e.g., base=5 uses {1,2,3,4,5})
- Added `max_digits` config option (default: 10) - determines the maximum label length
- Auto-generates all possible combinations up to the specified length
- Asserts a minimum 100 combinations requirement, and throws an error messages if assertion fails
- Old `labels` option still supported and takes precedence over auto-generation
- Updated README with simplified configuration examples

**Benefits:**
- Much simpler configuration for users
- Eliminates the "running out of numbers" issue 
  - Default config now yields 12,207,030 combinations (effectively unlimited)
  - Minimum 100 combination check makes it so only extreme edge cases can fail 
- Backward compatible - existing manual label configs still work 
  - Taking precedence over the "lazier" method also allows power users to easily override defaults 

## Example Usage
```lua
require('comfy-line-numbers').setup({
  base = 5,         -- Use digits 1-5 (default)
  max_digits = 10,  -- Generate up to 10-digit combinations (default)
})
```

## Test Plan
- [x] Tested default configuration (base=5, max_digits=10): 12,207,030 labels generated
- [x] Tested various base values (3-9) with different max_digits
- [x] Verified manual labels override auto-generation
- [x] Verified validation errors for insufficient combinations
- [x] Verified backward compatibility with existing manual label configs