### PR TITLE
fix: Add filetype autocommand, so that filetype of a buffer is determined AFTER the filetype was set.

### DIFF
--- a/lua/comfy-line-numbers/init.lua
+++ b/lua/comfy-line-numbers/init.lua
@@ -185,7 +185,7 @@ end
 function create_auto_commands()
   local group = vim.api.nvim_create_augroup("ComfyLineNumbers", { clear = true })
 
-  vim.api.nvim_create_autocmd({ "WinNew", "BufWinEnter", "BufEnter", "TermOpen", "InsertEnter", "InsertLeave" }, {
+  vim.api.nvim_create_autocmd({ "WinNew", "BufWinEnter", "BufEnter", "TermOpen", "InsertEnter", "InsertLeave", "FileType" }, {
     group = group,
     pattern = "*",
     callback = update_status_column


### PR DESCRIPTION


If you use a plugin like alpha.nvim you'll see filetype 'alpha' is ignored at first when starting neovim and as a result linenumbers are shown. Only when you move to another window, those line will be hidden. I assume this is because currently the plugin checks filetype before filetype of a buffer was actually set. So adding this will check line numbers every time filetype of a buffer is set. Which kind of makes sense, considering that filetype of a buffer is not set in stone, you can change it for any buffer.